### PR TITLE
Rename YANG leaf schedule-type to schedule-class

### DIFF
--- a/draft-ietf-opsawg-scheduling-oam-tests.md
+++ b/draft-ietf-opsawg-scheduling-oam-tests.md
@@ -269,7 +269,7 @@ module: ietf-oam-unitary-test
         |        +--rw interval?                 uint32
         +--rw state?                    identityref
         +--rw version?                  uint16
-        +--rw schedule-type?            identityref
+        +--rw schedule-class?            identityref
         +--ro local-time?               yang:date-and-time
         +--ro last-update?              yang:date-and-time
         +--ro counter?                  yang:counter32


### PR DESCRIPTION
Rename the YANG leaf 'schedule-type' to 'schedule-class' in the ietf-oam-unitary-test module within draft-ietf-opsawg-scheduling-oam-tests.md to reflect updated naming. Update any references to this leaf as needed to match the new identifier.